### PR TITLE
fix install kubebuilder error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ export DOCKER_BUILDER    ?= docker
 
 export KUBECONFIG ?= ${HOME}/.kube/config
 
+export KUBEBUILDER_HOME := /usr/local/kubebuilder
+
+export PATH := ${PATH}:${KUBEBUILDER_HOME}/bin
+
 BEFORE_SCRIPT := $(shell build/before-make.sh)
 
 all: build-image


### PR DESCRIPTION
Fix below error as KUBEBUILDER_HOME doesn't have a default value.
```
# make check
go-bindata 3.1.3 (Go runtime go1.15.10).
Copyright (c) 2010-2013, Jim Teeuwen.
which: no kubebuilder in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/usr/local/go/bin:/root/go/bin:/root/bin:/usr/local/go/bin:/root/go/bin:/usr/local/go/bin:/root/go/bin)
Install Kubebuilder components for test framework usage!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    68  100    68    0     0    139      0 --:--:-- --:--:-- --:--:--   139
100   123  100   123    0     0    202      0 --:--:-- --:--:-- --:--:--   202
100   644  100   644    0     0    985      0 --:--:-- --:--:-- --:--:--   985
100 54.8M  100 54.8M    0     0  22.0M      0  0:00:02  0:00:02 --:--:-- 31.1M
mv: missing destination file operand after ‘/tmp/kubebuilder_2.3.0_linux_amd64’
Try 'mv --help' for more information.
make: *** [dependencies] Error 1
```
Signed-off-by: haoqing0110 <qhao@redhat.com>